### PR TITLE
Added communities list as a separate view

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		398DE0662A3F85FA00D4BD1B /* Communities List View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398DE0652A3F85FA00D4BD1B /* Communities List View.swift */; };
 		503BA26F2A2C94540052516C /* URL+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503BA26E2A2C94540052516C /* URL+Identifiable.swift */; };
 		508845CF2A3641160088E483 /* JSONDecoder+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508845CE2A3641160088E483 /* JSONDecoder+Default.swift */; };
 		50EC39B22A346DDC00E014C2 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EC39B12A346DDC00E014C2 /* URLHandler.swift */; };
@@ -194,6 +195,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		398DE0652A3F85FA00D4BD1B /* Communities List View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Communities List View.swift"; sourceTree = "<group>"; };
 		503BA26E2A2C94540052516C /* URL+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifiable.swift"; sourceTree = "<group>"; };
 		508845CE2A3641160088E483 /* JSONDecoder+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Default.swift"; sourceTree = "<group>"; };
 		50EC39B12A346DDC00E014C2 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
@@ -554,6 +556,7 @@
 			children = (
 				6332FDCE27EFDD2E0009A98A /* Accounts Page.swift */,
 				63F0C7B82A0533C700A18C5D /* Add Account View.swift */,
+				398DE0652A3F85FA00D4BD1B /* Communities List View.swift */,
 			);
 			path = "Instance and Community List";
 			sourceTree = "<group>";
@@ -1299,6 +1302,7 @@
 				6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */,
 				CD04D5E52A362AD3008EF95B /* Post Header.swift in Sources */,
 				6318EDC927EE4E1C00BFCAE8 /* Comment.swift in Sources */,
+				398DE0662A3F85FA00D4BD1B /* Communities List View.swift in Sources */,
 				6322A5D227F88CFD00135D4F /* Time Parser.swift in Sources */,
 				637218612A3A2AAD008C4816 /* CreatePostLike.swift in Sources */,
 				63CE4E712A06B21B00405271 /* Avatar View.swift in Sources */,

--- a/Mlem/Settings.bundle/Root.plist
+++ b/Mlem/Settings.bundle/Root.plist
@@ -4,58 +4,5 @@
 <dict>
 	<key>StringsTable</key>
 	<string>Root</string>
-	<key>PreferenceSpecifiers</key>
-	<array>
-		<dict>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>Title</key>
-			<string>Group</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSTextFieldSpecifier</string>
-			<key>Title</key>
-			<string>Name</string>
-			<key>Key</key>
-			<string>name_preference</string>
-			<key>DefaultValue</key>
-			<string></string>
-			<key>IsSecure</key>
-			<false/>
-			<key>KeyboardType</key>
-			<string>Alphabet</string>
-			<key>AutocapitalizationType</key>
-			<string>None</string>
-			<key>AutocorrectionType</key>
-			<string>No</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Enabled</string>
-			<key>Key</key>
-			<string>enabled_preference</string>
-			<key>DefaultValue</key>
-			<true/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSSliderSpecifier</string>
-			<key>Key</key>
-			<string>slider_preference</string>
-			<key>DefaultValue</key>
-			<real>0.5</real>
-			<key>MinimumValue</key>
-			<integer>0</integer>
-			<key>MaximumValue</key>
-			<integer>1</integer>
-			<key>MinimumValueImage</key>
-			<string></string>
-			<key>MaximumValueImage</key>
-			<string></string>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -487,6 +487,12 @@ struct CommunityView: View
                 account: account
             )
         } catch APIClientError.networking {
+            // TODO: we're seeing a number of SSL related errors on some instances while loading pages from the feed
+            // while we investigate the reasons we will only show this error if the user would otherwise be left with an empty feed
+            guard postTracker.posts.isEmpty else {
+                return
+            }
+            
             errorAlert = .init(
                 title: "Unable to connect to Lemmy",
                 message: "Please check your internet connection and try again"
@@ -497,7 +503,10 @@ struct CommunityView: View
                 message: message.error
             )
         } catch {
-            errorAlert = .unexpected
+            // TODO: we may be receiving decoding errors (or something else) based on reports in the dev chat
+            // for now we will fail silently if the user has posts to view while we investigate further
+            assertionFailure("Unhandled error encountered, if you can reproduce this please raise a ticket/discuss in the dev chat")
+            // errorAlert = .unexpected
         }
 
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -66,6 +66,7 @@ struct CommunityView: View
         ZStack(alignment: .top)
         {
             searchResultsView
+                .accessibilityHidden(!isShowingCommunitySearch)
             ScrollView {
                 if postTracker.posts.isEmpty {
                     noPostsView
@@ -241,6 +242,10 @@ struct CommunityView: View
                         Image(systemName: "chevron.down")
                             .scaleEffect(0.7)
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(community?.name ?? feedType.rawValue)")
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityHint("Activate to search and select feeds")
                     .onTapGesture
                     {
                         isSearchFieldFocused = true
@@ -249,11 +254,15 @@ struct CommunityView: View
                         {
                             isShowingCommunitySearch.toggle()
                         }
+
                     }
                 }
                 else
                 {
                     CommunitySearchField(isSearchFieldFocused: $isSearchFieldFocused, searchText: $searchText, account: account)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Search for communities.")
+                        .accessibilityAddTraits(.isSearchField)
                 }
             }
         }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Large Post.swift
@@ -73,5 +73,6 @@ struct LargePost: View {
             
             PostInteractionBar(post: post, account: account, compact: false, voteOnPost: voteOnPost)
         }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Large Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Large Post.swift
@@ -50,22 +50,13 @@ struct LargePost: View {
                     } placeholder: {
                         ProgressView()
                     }
+                    postBodyView
                 case .link:
                     WebsiteIconComplex(post: post.post)
                         .padding(.horizontal)
-                case .text(let postBody):
-                    if !postBody.isEmpty {
-                        if isExpanded {
-                            MarkdownView(text: postBody)
-                                .font(.subheadline)
-                                .padding(.horizontal)
-                        } else {
-                            MarkdownView(text: postBody.components(separatedBy: .newlines).joined())
-                                .lineLimit(8)
-                                .font(.subheadline)
-                                .padding(.horizontal)
-                        }
-                    }
+                    postBodyView
+                case .text:
+                    postBodyView
                 case .titleOnly:
                     EmptyView()
                 }
@@ -74,5 +65,23 @@ struct LargePost: View {
             PostInteractionBar(post: post, account: account, compact: false, voteOnPost: voteOnPost)
         }
         .accessibilityElement(children: .combine)
+    }
+    
+    // MARK: - Subviews
+    
+    @ViewBuilder
+    var postBodyView: some View {
+        if let bodyText = post.post.body, !bodyText.isEmpty {
+            if isExpanded {
+                MarkdownView(text: bodyText)
+                    .font(.subheadline)
+                    .padding(.horizontal)
+            } else {
+                MarkdownView(text: bodyText.components(separatedBy: .newlines).joined())
+                    .lineLimit(8)
+                    .font(.subheadline)
+                    .padding(.horizontal)
+            }
+        }
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Header.swift
@@ -13,6 +13,7 @@ struct PostHeader: View {
     // parameters
     var post: APIPostView
     var account: SavedAccount
+    @State private var isShowingCommunity = false
     
     // constants
     private let communityIconSize: CGFloat = 32
@@ -22,7 +23,8 @@ struct PostHeader: View {
         HStack {
             HStack(spacing: 4) {
                 // community avatar and name
-                NavigationLink(destination: CommunityView(account: account, community: post.community, feedType: .all)) {
+                NavigationLink(destination: CommunityView(account: account, community: post.community, feedType: .all),
+                               isActive: $isShowingCommunity) {
                     communityAvatar
                         .frame(width: communityIconSize, height: communityIconSize)
                         .clipShape(Circle())
@@ -60,6 +62,9 @@ struct PostHeader: View {
         .accessibilityElement(children: .ignore)
         .accessibilityAddTraits(.isStaticText)
         .accessibilityLabel("in \(post.community.name) by \(post.creator.name)")
+        .accessibilityAction(named: "Goto \(post.community.name)") {
+            isShowingCommunity = true
+        }
         .font(.subheadline)
         .foregroundColor(.secondary)
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Header.swift
@@ -57,33 +57,39 @@ struct PostHeader: View {
                 StickiedTag(compact: false)
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isStaticText)
+        .accessibilityLabel("in \(post.community.name) by \(post.creator.name)")
         .font(.subheadline)
         .foregroundColor(.secondary)
     }
     
     @ViewBuilder
     private var communityAvatar: some View {
-        if let communityAvatarLink = post.community.icon {
-            CachedAsyncImage(url: communityAvatarLink) { image in
-                if let avatar = image.image {
-                    avatar
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: communityIconSize, height: communityIconSize)
-                }
-                else {
-                    Image("Default Community")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: defaultCommunityIconSize, height: defaultCommunityIconSize)
+        Group {
+            if let communityAvatarLink = post.community.icon {
+                CachedAsyncImage(url: communityAvatarLink) { image in
+                    if let avatar = image.image {
+                        avatar
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: communityIconSize, height: communityIconSize)
+                    }
+                    else {
+                        Image("Default Community")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: defaultCommunityIconSize, height: defaultCommunityIconSize)
+                    }
                 }
             }
+            else {
+                Image("Default Community")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: defaultCommunityIconSize, height: defaultCommunityIconSize)
+            }
         }
-        else {
-            Image("Default Community")
-                .resizable()
-                .scaledToFit()
-                .frame(width: defaultCommunityIconSize, height: defaultCommunityIconSize)
-        }
+        .accessibilityHidden(true)
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Interaction Bar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Interaction Bar.swift
@@ -56,6 +56,11 @@ struct PostInteractionBar: View {
                 VoteComplex(vote: displayedVote, score: displayedScore, upvote: upvote, downvote: downvote)
                     .padding(.trailing, 8)
                 SaveButton(saved: false)
+                    .accessibilityAction(named: saveButtonText(saved: dirtySaved), {
+                        Task(priority: .userInitiated) {
+                            await savePost()
+                        }
+                    })
                     .onTapGesture {
                         Task(priority: .userInitiated) {
                             await savePost()
@@ -89,15 +94,28 @@ struct PostInteractionBar: View {
                 Image(systemName: "clock")
                 Text(getTimeIntervalFromNow(date: post.post.published))
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Posted \(getTimeIntervalFromNow(date: post.post.published))")
+            
             HStack(spacing: iconToTextSpacing) {
                 Image(systemName: "bubble.left")
                 Text(String(post.counts.comments))
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(post.counts.comments) comments")
         }
         .foregroundColor(.secondary)
     }
     
     // helper functions
+    
+    // Not sure if this is working yet, need to revisit after save post is implemented.
+    func saveButtonText(saved: Bool) -> String {
+        if saved {
+            return "Unsave"
+        }
+        return "Save"
+    }
     
     func upvote() async -> Void {
         // don't do anything if currently awaiting a vote response
@@ -156,5 +174,6 @@ struct PostInteractionBar: View {
      */
     func savePost() async {
         // TODO: implement
+        UIAccessibility.post(notification: .announcement, argument: "Not yet implemented")
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Accounts Page.swift
@@ -54,7 +54,7 @@ struct AccountsPage: View
                         .onDelete(perform: deleteAccount)
                         .navigationDestination(isPresented: accountNavigationBinding(), destination: {
                             if let account = accountsTracker.savedAccounts.first {
-                                CommunityView(account: account, community: nil)
+                                CommunitiesListView(account: account)
                                     .onAppear
                                 {
                                     appState.currentActiveAccount = account

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Communities List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Instance and Community List/Communities List View.swift
@@ -1,0 +1,115 @@
+//
+//  Communities View.swift
+//  Mlem
+//
+//  Created by Ethan Hargus on 6/18/23.
+//
+
+import SwiftUI
+
+struct CommunitiesListView: View {
+    @EnvironmentObject var favoritedCommunitiesTracker: FavoriteCommunitiesTracker
+    @State var subscribedCommunities: [APICommunity]?
+
+    var account: SavedAccount
+    
+    var body: some View {
+        VStack (alignment: .leading, spacing: 10) {
+            List {
+                Section {
+                    NavigationLink(destination: CommunityView(account: account, community: nil, feedType: .subscribed)) {
+                        Label("Subscribed", systemImage: "house")
+                    }
+                    
+                    NavigationLink(destination: CommunityView(account: account, community: nil, feedType: .all)) {
+                        Label("All", systemImage: "rectangle.stack.fill")
+                    }
+                }
+                
+                Section {
+                    if !getFavoritedCommunitiesForAccount(account: account, tracker: favoritedCommunitiesTracker).isEmpty
+                    {
+                        ForEach(getFavoritedCommunitiesForAccount(account: account, tracker: favoritedCommunitiesTracker))
+                        { favoritedCommunity in
+                            NavigationLink(destination: CommunityView(account: account, community: favoritedCommunity.community, feedType: .all))
+                            {
+                                Text("\(favoritedCommunity.community.name)\(Text("@\(favoritedCommunity.community.actorId.host ?? "ERROR")").foregroundColor(.secondary).font(.caption))")
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: true)
+                                {
+                                    Button(role: .destructive)
+                                    {
+                                        unfavoriteCommunity(account: account, community: favoritedCommunity.community, favoritedCommunitiesTracker: favoritedCommunitiesTracker)
+                                    } label: {
+                                        Label("Unfavorite", systemImage: "star.slash")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        VStack(alignment: .center, spacing: 10)
+                        {
+                            Image(systemName: "star.slash")
+                            Text("You have no communities favorited")
+                        }
+                        .listRowBackground(Color.clear)
+                        .frame(maxWidth: .infinity)
+                    }
+                } header: {
+                    Text("Favorites")
+                }
+                
+                Section {
+                    if subscribedCommunities != nil {
+                        if !subscribedCommunities!.isEmpty
+                        {
+                            ForEach(subscribedCommunities!)
+                            { subscribedCommunity in
+                                NavigationLink(destination: CommunityView(account: account, community: subscribedCommunity, feedType: .all))
+                                {
+                                    Text("\(subscribedCommunity.name)\(Text("@\(subscribedCommunity.actorId.host!)").foregroundColor(.secondary).font(.caption))")
+                                        .swipeActions(edge: .trailing, allowsFullSwipe: true)
+                                    {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        VStack(alignment: .center, spacing: 10)
+                        {
+                            Image(systemName: "star.slash")
+                            Text("You have no community subscriptions")
+                        }
+                        .listRowBackground(Color.clear)
+                        .frame(maxWidth: .infinity)
+                    }
+                    
+                } header: {
+                    Text("Subscribed")
+                }
+            }
+        }
+        .task {
+            let request = ListCommunitiesRequest(account: account, sort: nil, page: nil, limit: nil, type: FeedType.subscribed);
+            do {
+                let response = try await APIClient().perform(request: request);
+                subscribedCommunities = response.communities.map({
+                    return $0.community;
+                }).sorted(by: {
+                    $0.name < $1.name
+                });
+            } catch {
+                
+            }
+        }
+    }
+    
+    internal func getFavoritedCommunitiesForAccount(account: SavedAccount, tracker: FavoriteCommunitiesTracker) -> [FavoriteCommunity]
+    {
+        return tracker.favoriteCommunities.filter { $0.forAccountID == account.id }
+    }
+}
+

--- a/Mlem/Views/Tabs/Posts/Components/Shared/Buttons/Vote Complex/Vote Complex.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Shared/Buttons/Vote Complex/Vote Complex.swift
@@ -18,11 +18,30 @@ struct VoteComplex: View {
     let downvote: () async -> Void
     
     var body: some View {
-        switch voteComplexStyle {
-        case .standard:
-            StandardVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
-        case .symmetric:
-            SymmetricVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
+        Group {
+            switch voteComplexStyle {
+            case .standard:
+                StandardVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
+            case .symmetric:
+                SymmetricVoteComplex(vote: vote, score: score, upvote: upvote, downvote: downvote)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityValue("\(score) votes")
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                Task(priority: .userInitiated) {
+                    await upvote()
+                }
+            case .decrement:
+                Task(priority: .userInitiated) {
+                    await downvote()
+                }
+            default:
+                // Not sure what to do here.
+                UIAccessibility.post(notification: .announcement, argument: "Unknown Action")
+            }
         }
     }
 }


### PR DESCRIPTION
Since I saw you already had a PR open I thought I'd just make changes to your fork :P 

# Changes
I added a new view (CommunitiesListView) as a view between the accounts screen and the main feed view that does exactly what the search view does, except that its a separate view this time. I mostly just moved around/copied a lot of code since I don't know swift all that well, but I think the result turned out pretty decent! It looks more Apollo-adjacent and is much nicer to use IMO

# Screenshots

![Simulator Screenshot - iPhone 14 Pro - 2023-06-18 at 14 15 46](https://github.com/JakeShirley/Mlem/assets/7621694/cc8090ef-fc33-4f4e-8313-8dbcec41dd5f)

# Notes
I haven't tested this a whole lot, so there will probably be issues I don't know about. It is also basically the same code as the search bar, just without the searching capabilities, so it might be worth removing the duplicated code from the search bar component, but I didn't want to go too crazy on the UI changes. Also this is one of very few PR's I have made, so if there's anything I'm missing here, or that you think I could change, do let me know!